### PR TITLE
Update ossec_agent.conf

### DIFF
--- a/etc/nsm/ossec/ossec_agent.conf
+++ b/etc/nsm/ossec/ossec_agent.conf
@@ -10,7 +10,7 @@ set DEBUG 0
 
 # Run in background
 # 1=yes 0=no
-set DAEMON 1
+set DAEMON 0
 
 # Name of sguild server
 set SERVER_HOST localhost

--- a/etc/nsm/ossec/ossec_agent.conf
+++ b/etc/nsm/ossec/ossec_agent.conf
@@ -36,3 +36,7 @@ set DNS 127.0.0.1
 # alert text
 set DEFAULT_DNS_DOMAIN test.com
 
+# Do you want to enable DNS lookups?
+# USE_DNS 1 - hostnames will be converted to IP via DNS
+# USE_DNS 0 - hostnames will be replaced with 0.0.0.0
+set USE_DNS 0


### PR DESCRIPTION
Missing USE_DNS variable to enable/disable DNS hostname lookups
