### PR TITLE
optimization and cleanups

### DIFF
--- a/etc/nsm/ossec/ossec_agent.tcl
+++ b/etc/nsm/ossec/ossec_agent.tcl
@@ -81,14 +81,13 @@ proc bgerror { errorMsg } {
 proc InitAgent {} {
 
     global DEBUG FILENAME MIN_PRIORITY  DNS DEFAULT_DNS_DOMAIN USE_DNS
-    global nDate sig_id priority message src_ip user hexPayload payload agent src_port dst_port
+    global nDate sig_id priority message src_ip hexPayload payload agent src_port dst_port
 
     set nDate ""
     set sig_id ""
     set priority ""
     set message ""
     set src_ip ""
-    set user ""
     set hexPayload ""
     set payload ""
     set agent ""
@@ -201,7 +200,7 @@ proc ResolveHostname { hostName } {
 #
 proc ProcessData { line } {
     global AGENT_TYPE
-    global nDate sig_id priority message src_ip user hexPayload payload agent src_port dst_port
+    global nDate sig_id priority message src_ip hexPayload payload agent src_port dst_port
 
     # We do not care about the first line of an alert so find it and forget it
     if { [regexp {(?x) ^\*\*\s+Alert} $line] } {
@@ -228,26 +227,13 @@ proc ProcessData { line } {
                  ^Rule:\s+(\d+)\s+\(level\s+(\d+)\)\s+->\s+'(.*)'
                  } $line MatchVar sig_id priority message ] } {
         set message "\[[string toupper $AGENT_TYPE]\] $message"
-    } elseif { [regexp {(?x)
-                 ^User:\s+(.*)
-                } $line MatchVar user ] } {
-        # We really don't have anything to do here, since we matched all
-        # our variables directly in the conditional for this block
-    } elseif { [regexp {(?x)
-                 ^Src\s+IP:\s+(.*)
-                 } $line MatchVar src_ip ] } {
+    } elseif { [regexp {(?x) ^Src\s+IP:\s+(\S+)} $line MatchVar src_ip ] } {
         set src_ip [ResolveHostname $src_ip]
-    } elseif { [regexp {(?x)
-                 ^Src\s+Port:\s+(\d+)
-                 } $line MatchVar src_port ] } {
+    } elseif { [regexp {(?x) ^Src\s+Port:\s+(\d+)} $line MatchVar src_port ] } {
         # nothing to do as regexp filled the var
-    } elseif { [regexp {(?x)
-                 ^Dst\s+IP:\s+(.*)
-                 } $line MatchVar agent ] } {
+    } elseif { [regexp {(?x) ^Dst\s+IP:\s+(\S+)} $line MatchVar agent ] } {
         set agent [ResolveHostname $agent]
-    } elseif { [regexp {(?x)
-                 ^Dst\s+Port:\s+(\d+)
-                 } $line MatchVar dst_port ] } {
+    } elseif { [regexp {(?x) ^Dst\s+Port:\s+(\d+)} $line MatchVar dst_port ] } {
         # nothing to do as regexp filled the var
     # check to see if this is a blank line
     # if it is then we've reached the end of the alert and can now send it to Sguil
@@ -268,7 +254,7 @@ proc SendAlert {} {
     global HOSTNAME IPADDR AGENT_ID NEXT_EVENT_ID AGENT_TYPE GEN_ID
     global MIN_PRIORITY
     global sguildSocketID DEBUG
-    global nDate sig_id priority message src_ip user hexPayload payload agent src_port dst_port
+    global nDate sig_id priority message src_ip hexPayload payload agent src_port dst_port
 
     # If we meet the minimum priority threshold to issue an alert,
     # do it here.
@@ -280,7 +266,6 @@ proc SendAlert {} {
            puts "\tSigID: $sig_id"
            puts "\tPriority: $priority"
            puts "\tSrcIP: $src_ip"
-           puts "\tUser: $user"
            puts "\tMessage: $message"
            puts "\tPayload: $payload"
            puts "\tSrcPort: $src_port"
@@ -357,7 +342,6 @@ proc SendAlert {} {
     set sig_id ""
     set priority ""
     set src_ip ""
-    set user ""
     set message ""
     set payload ""
     set hexPayload ""


### PR DESCRIPTION
I removed the "user" global variable as there is no need to parse out the user in the logs for Sguil.  There isn't a Sguil DB field for user.  Therefore if OSSEC decodes it just add it to the body of the alert.  This makes it easier to identify the user account associated with the log when viewing the alert detail in Sguil as it will be on a separate line at the top of the alert detail.

I also made the processdata procedure a little easier for me to read.

In the processdata procedure I also replaced the ".*" for SRC IP and DST IP matching with "\S+".

Having an issue that some of my SRC and DST ports for alerts are not getting imported into Sguil even though they are being decoded in OSSEC and the ossec-agent.tcl script is parsing them out as they are not showing up in the Sguil alert detail.  Not sure what is causing this yet as some come into Sguil without issue.
