### PR TITLE
Add source of syslog as destination IP for Sguil alert

### DIFF
--- a/etc/nsm/ossec/ossec_agent.tcl
+++ b/etc/nsm/ossec/ossec_agent.tcl
@@ -212,8 +212,8 @@ proc ProcessData { line } {
     } elseif { ([regexp {(?x)
 #           ^(\d\d\d\d)\s+(...)\s+(\d\d)\s+(\d\d:\d\d:\d\d)\s+(.*)->
 #         ^(\d\d\d\d)\s+(...)\s+(\d\d)\s+(\d\d:\d\d:\d\d)\s+(\(.*\)\s+)*(.*)->
-                 ^(\d\d\d\d)\s+(...)\s+(\d\d)\s+(\d\d:\d\d:\d\d)\s+(\(.*\)\s+)*(\S+)->
-                 } $line MatchVar year month day time placeholder agent]) } {
+                 ^(\d\d\d\d)\s+(...)\s+(\d\d)\s+(\d\d:\d\d:\d\d)\s+(\(.*\)\s+)*(\S+)->(\d+.\d+.\d+.\d+)*
+                 } $line MatchVar year month day time placeholder agent SyslogSource]) } {
         set nDate [clock format [clock scan "$day $month $year $time" ] -gmt true -f "%Y-%m-%d %T"]
         # Ok, this is confusing, but the regexp can return either one
         # or two variables, depending on the format of the input line.
@@ -222,7 +222,13 @@ proc ProcessData { line } {
         # usually just be one field (either a hostname or an IP address,
         # depending on the log source).  In either case, the $agent
         # variable ends up holding the correct value for our purposes.
-        set agent [ResolveHostname $agent]
+        # SyslogSource will pull out the IP of the device sending a 
+        # syslog to OSSEC.
+        if {[string length $SyslogSource] != 0} {
+            set agent $SyslogSource
+        } else {
+            set agent [ResolveHostname $agent]
+        }
     } elseif { [regexp {(?x)
                  ^Rule:\s+(\d+)\s+\(level\s+(\d+)\)\s+->\s+'(.*)'
                  } $line MatchVar sig_id priority message ] } {

--- a/etc/nsm/ossec/ossec_agent.tcl
+++ b/etc/nsm/ossec/ossec_agent.tcl
@@ -213,7 +213,7 @@ proc ProcessData { line } {
 #           ^(\d\d\d\d)\s+(...)\s+(\d\d)\s+(\d\d:\d\d:\d\d)\s+(.*)->
 #         ^(\d\d\d\d)\s+(...)\s+(\d\d)\s+(\d\d:\d\d:\d\d)\s+(\(.*\)\s+)*(.*)->
                  ^(\d\d\d\d)\s+(...)\s+(\d\d)\s+(\d\d:\d\d:\d\d)\s+(\(.*\)\s+)*(\S+)->(\d+.\d+.\d+.\d+)*
-                 } $line MatchVar year month day time placeholder agent SyslogSource]) } {
+                 } $line MatchVar year month day time placeholder agent syslog_source]) } {
         set nDate [clock format [clock scan "$day $month $year $time" ] -gmt true -f "%Y-%m-%d %T"]
         # Ok, this is confusing, but the regexp can return either one
         # or two variables, depending on the format of the input line.
@@ -224,8 +224,8 @@ proc ProcessData { line } {
         # variable ends up holding the correct value for our purposes.
         # SyslogSource will pull out the IP of the device sending a 
         # syslog to OSSEC.
-        if {[string length $SyslogSource] != 0} {
-            set agent $SyslogSource
+        if {[string length $syslog_source] != 0} {
+            set agent $syslog_source
         } else {
             set agent [ResolveHostname $agent]
         }


### PR DESCRIPTION
Some syslogs do not contain the IP of the device sending the syslog in the body of the syslog.  Cisco ASAs do this with some syslog messages.  Therefore I added to the regex to pull this information out if it exists in the second line of the OSSEC alert.
